### PR TITLE
Feature/3 Adicionar coleção django-extensions ao Projeto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ tox==3.27.1
 django-allauth==0.51.0
 dj-rest-auth==2.2.5
 msgram-core==1.3.2
+django-extensions==3.2.3

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -52,6 +52,7 @@ DJANGO_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.sites",
+    "django_extensions",
 ]
 
 THIRD_PARTY_APPS = [


### PR DESCRIPTION
# Adicionar coleção *django-extensions* ao Projeto

## Descrição

Adicionar coleção *django-extensions* ao Projeto para permitir usar o comando *graph models* para gerar o diagrama entidade-relacionamento.

Issue Relacionada:
[Adicionar a coleção *django-extensions* ao projeto](https://github.com/fga-eps-mds/2023.2-MeasureSoftGram-DOC/issues/3)

## Porque este *Pull Request* é necessário?

Esse *Pull Request* pretende de deixar o projeto já configurado com o *django-extensions* para contribuintes futuros conseguirem gerar o diagrama entidade-relacionamento e visualizar as novas alterações na base de dados e poder comparar com antigas e entender melhor como funciona.

## Critérios de aceitação

- [x] Gerar o diagrama entidade-relacionamento.

## Referências

- [Documentação comando *graph models* com tutorial para usar](https://django-extensions.readthedocs.io/en/latest/graph_models.html)
- [Documentação *django-extensions*](https://django-extensions.readthedocs.io/en/latest/index.html)

## Diagrama Entidade-Relacionamento

![models](https://github.com/fga-eps-mds/2023-2-MeasureSoftGram-Service/assets/54439337/d1047e45-5ba1-4c0c-9a2e-2aaf3f1b1e6f)

